### PR TITLE
Fix build and start scripts path references

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
   <img width="380" height="200" src="https://glama.ai/mcp/servers/@phxdev1/archy-mcp/badge" />
 </a>
 
-
 # Archy - Architectural Diagram Builder
 
 Archy is an MCP (Model Context Protocol) server that generates architectural diagrams using Mermaid syntax. It can process both natural language descriptions and GitHub repository URLs to create various types of diagrams.
@@ -31,17 +30,19 @@ Archy is an MCP (Model Context Protocol) server that generates architectural dia
 
 - Node.js (v16 or higher)
 - npm (v7 or higher)
-- TypeScript (v5.8 or higher, included in dependencies)
+- TypeScript (v5.8 or higher, included in devDependencies)
 
 ### Install from Source
 
 1. Clone the repository:
+
    ```bash
    git clone https://github.com/phxdev1/archy.git
    cd archy
    ```
 
 2. Install dependencies:
+
    ```bash
    npm install
    ```
@@ -50,7 +51,7 @@ Archy is an MCP (Model Context Protocol) server that generates architectural dia
    ```bash
    npm run build
    ```
-   This compiles the TypeScript source files to JavaScript in the `build` directory.
+   This compiles the TypeScript source files to JavaScript in the `build/src` directory.
 
 ### Automated MCP Installation
 
@@ -61,6 +62,7 @@ npm run install-mcp
 ```
 
 This script:
+
 - Automatically detects the correct MCP settings locations for your operating system
 - Updates the MCP configuration files for VS Code and Claude
 - Prompts for a GitHub token for repository analysis (optional)
@@ -119,7 +121,7 @@ To use Archy with an MCP client, add it to your MCP settings file if you're a ma
   "mcpServers": {
     "archy": {
       "command": "node",
-      "args": ["/path/to/archy/build/index.js"],
+      "args": ["/path/to/archy/build/src/index.js"],
       "env": {
         "GITHUB_TOKEN": "your-github-token"
       }
@@ -135,10 +137,12 @@ To use Archy with an MCP client, add it to your MCP settings file if you're a ma
 Generates a Mermaid diagram from a text description.
 
 **Parameters:**
+
 - `description`: Text description of the diagram to generate
 - `diagramType`: Type of diagram to generate (e.g., 'flowchart', 'classDiagram', etc.)
 
 **Example:**
+
 ```json
 {
   "description": "A user authentication system with login, registration, and password reset",
@@ -151,10 +155,12 @@ Generates a Mermaid diagram from a text description.
 Generates a Mermaid diagram from a GitHub repository.
 
 **Parameters:**
+
 - `repoUrl`: URL of the GitHub repository
 - `diagramType`: Type of diagram to generate (e.g., 'classDiagram', 'sequenceDiagram', etc.)
 
 **Example:**
+
 ```json
 {
   "repoUrl": "https://github.com/username/repository",
@@ -177,11 +183,13 @@ The following tools are available when an OpenRouter API key is configured:
 Generates a Mermaid diagram from a text description using AI (LangChain with OpenRouter).
 
 **Parameters:**
+
 - `description`: Text description of the diagram to generate
 - `diagramType`: Type of diagram to generate (e.g., 'flowchart', 'classDiagram', etc.)
 - `useAdvancedModel`: (Optional) Whether to use a more advanced AI model for complex diagrams
 
 **Example:**
+
 ```json
 {
   "description": "A microservice architecture with user service, product service, and order service communicating through a message queue",
@@ -195,10 +203,12 @@ Generates a Mermaid diagram from a text description using AI (LangChain with Ope
 Generates a Mermaid diagram from code using AI.
 
 **Parameters:**
+
 - `code`: The code to analyze and generate a diagram from
 - `diagramType`: Type of diagram to generate (e.g., 'classDiagram', 'flowchart', etc.)
 
 **Example:**
+
 ```json
 {
   "code": "class User { ... } class AuthService { ... }",
@@ -211,11 +221,13 @@ Generates a Mermaid diagram from code using AI.
 Generates a Mermaid diagram showing differences between two versions of code.
 
 **Parameters:**
+
 - `beforeCode`: The code before changes
 - `afterCode`: The code after changes
 - `diagramType`: Type of diagram to generate (e.g., 'classDiagram', 'flowchart', etc.)
 
 **Example:**
+
 ```json
 {
   "beforeCode": "class User { ... }",
@@ -229,6 +241,7 @@ Generates a Mermaid diagram showing differences between two versions of code.
 Exports a Mermaid diagram to an image format (PNG, SVG, or PDF).
 
 **Parameters:**
+
 - `mermaidCode`: The Mermaid diagram code to export
 - `format`: (Optional) The image format to export to ('png', 'svg', 'pdf', default: 'png')
 - `width`: (Optional) The width of the image in pixels (default: 800)
@@ -236,6 +249,7 @@ Exports a Mermaid diagram to an image format (PNG, SVG, or PDF).
 - `backgroundColor`: (Optional) The background color of the image (CSS color or "transparent", default: '#ffffff')
 
 **Example:**
+
 ```json
 {
   "mermaidCode": "flowchart TD\n  A[Start] --> B[End]",
@@ -251,12 +265,14 @@ Exports a Mermaid diagram to an image format (PNG, SVG, or PDF).
 Generates a diagram showing the evolution of a repository over time.
 
 **Parameters:**
+
 - `repoUrl`: URL of the GitHub repository
 - `diagramType`: Type of diagram to generate (e.g., 'gitGraph', 'flowchart', etc.)
 - `filepath`: (Optional) Path to a specific file to track
 - `commitLimit`: (Optional) Maximum number of commits to analyze (default: 10)
 
 **Example:**
+
 ```json
 {
   "repoUrl": "https://github.com/username/repository",
@@ -278,6 +294,7 @@ generate_diagram_from_text({
 ```
 
 Result:
+
 ```mermaid
 classDiagram
   class Book {
@@ -309,6 +326,7 @@ generate_diagram_from_github({
 ```
 
 Result:
+
 ```mermaid
 flowchart TD
   A[Client] --> B[API Gateway]
@@ -409,11 +427,11 @@ Archy is built with TypeScript using the following configuration:
 ```
 
 Key TypeScript features used:
+
 - ES2020 target for modern JavaScript features
 - NodeNext module resolution for compatibility with Node.js
 - Declaration files generation for better type support
 - Source maps for easier debugging
-
 
 ### Project Structure
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,18 +17,18 @@
         "mermaid": "^10.6.1",
         "openai": "^4.28.0",
         "puppeteer": "^21.11.0",
-        "typescript": "^5.8.3",
         "zod": "^3.24.3"
       },
       "bin": {
-        "archy": "build/index.js"
+        "archy": "build/src/index.js"
       },
       "devDependencies": {
         "@types/node": "^22.15.0",
         "cross-env": "^7.0.3",
         "esbuild-node-tsc": "^2.0.5",
         "nodemon": "^3.1.10",
-        "ts-node": "^10.9.2"
+        "ts-node": "^10.9.2",
+        "typescript": "^5.8.3"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -5006,6 +5006,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "archy",
   "version": "1.0.0",
-  "main": "build/index.js",
+  "main": "build/src/index.js",
   "type": "module",
   "scripts": {
-    "build": "tsc --project tsconfig.json && node build.cjs",
-    "start": "node build/index.js",
+    "build": "tsc --project tsconfig.json",
+    "start": "node build/src/index.js",
     "dev": "cross-env NODE_OPTIONS=--loader=ts-node/esm nodemon src/index.ts",
     "install-mcp": "cross-env NODE_OPTIONS=--loader=ts-node/esm ts-node install-mcp.ts",
     "examples": "cross-env NODE_OPTIONS=--loader=ts-node/esm ts-node examples/run-examples.ts",
@@ -29,7 +29,6 @@
     "mermaid": "^10.6.1",
     "openai": "^4.28.0",
     "puppeteer": "^21.11.0",
-    "typescript": "^5.8.3",
     "zod": "^3.24.3"
   },
   "devDependencies": {
@@ -37,10 +36,11 @@
     "cross-env": "^7.0.3",
     "esbuild-node-tsc": "^2.0.5",
     "nodemon": "^3.1.10",
-    "ts-node": "^10.9.2"
+    "ts-node": "^10.9.2",
+    "typescript": "^5.8.3"
   },
   "bin": {
-    "archy": "./build/index.js"
+    "archy": "./build/src/index.js"
   },
   "ts-node": {
     "esm": true,

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,6 +1,6 @@
 /**
  * Basic Test for Archy MCP Server
- * 
+ *
  * This script tests the basic functionality of the Archy MCP server
  * by simulating MCP client requests and verifying the responses.
  */
@@ -15,7 +15,7 @@ const __dirname = path.dirname(__filename);
 const rootDir = path.resolve(__dirname, '..');
 
 // Path to the server executable
-const serverPath = path.join(rootDir, 'build', 'index.js');
+const serverPath = path.join(rootDir, 'build', 'src', 'index.js');
 
 /**
  * Simulates an MCP client request to the server
@@ -28,27 +28,27 @@ async function sendRequest(request) {
     const server = spawn('node', [serverPath], {
       stdio: ['pipe', 'pipe', 'pipe']
     });
-    
+
     let stdout = '';
     let stderr = '';
-    
+
     // Collect stdout data
     server.stdout.on('data', (data) => {
       stdout += data.toString();
     });
-    
+
     // Collect stderr data
     server.stderr.on('data', (data) => {
       stderr += data.toString();
     });
-    
+
     // Handle process exit
     server.on('close', (code) => {
       if (code !== 0) {
         reject(new Error(`Server process exited with code ${code}\nStderr: ${stderr}`));
         return;
       }
-      
+
       try {
         // Parse the response
         const lines = stdout.trim().split('\n');
@@ -58,7 +58,7 @@ async function sendRequest(request) {
         reject(new Error(`Failed to parse server response: ${error.message}\nStdout: ${stdout}`));
       }
     });
-    
+
     // Send the request to the server
     server.stdin.write(JSON.stringify(request) + '\n');
     server.stdin.end();
@@ -70,7 +70,7 @@ async function sendRequest(request) {
  */
 async function runTests() {
   console.log('Running basic tests for Archy MCP server...\n');
-  
+
   try {
     // Test 1: Initialize the server
     console.log('Test 1: Initialize the server');
@@ -85,12 +85,12 @@ async function runTests() {
         }
       }
     };
-    
+
     const initResponse = await sendRequest(initRequest);
     console.log('Server initialized successfully');
     console.log('Server capabilities:', initResponse[0]?.result?.capabilities);
     console.log('');
-    
+
     // Test 2: List available tools
     console.log('Test 2: List available tools');
     const listToolsRequest = {
@@ -98,7 +98,7 @@ async function runTests() {
       id: 2,
       method: 'tools/list'
     };
-    
+
     const listToolsResponse = await sendRequest(listToolsRequest);
     const tools = listToolsResponse[0]?.result?.tools || [];
     console.log(`Found ${tools.length} tools:`);
@@ -106,7 +106,7 @@ async function runTests() {
       console.log(`- ${tool.name}: ${tool.description}`);
     });
     console.log('');
-    
+
     console.log('All tests passed!');
   } catch (error) {
     console.error('Test failed:', error.message);

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -1,21 +1,21 @@
 /**
  * Basic Test for Archy MCP Server
- * 
+ *
  * This script tests the basic functionality of the Archy MCP server
  * by simulating MCP client requests and verifying the responses.
  */
 
-import { spawn, ChildProcessWithoutNullStreams } from 'child_process';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { spawn, ChildProcessWithoutNullStreams } from "child_process";
+import path from "path";
+import { fileURLToPath } from "url";
 
 // Get the directory of this script
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const rootDir = path.resolve(__dirname, '..');
+const rootDir = path.resolve(__dirname, "..");
 
 // Path to the server executable
-const serverPath = path.join(rootDir, 'build', 'index.js');
+const serverPath = path.join(rootDir, "build", "src", "index.js");
 
 // Define types for the request and response
 interface McpRequest {
@@ -43,42 +43,52 @@ interface McpResponse {
 async function sendRequest(request: McpRequest): Promise<McpResponse[]> {
   return new Promise((resolve, reject) => {
     // Spawn the server process
-    const server: ChildProcessWithoutNullStreams = spawn('node', [serverPath], {
-      stdio: ['pipe', 'pipe', 'pipe']
+    const server: ChildProcessWithoutNullStreams = spawn("node", [serverPath], {
+      stdio: ["pipe", "pipe", "pipe"],
     });
-    
-    let stdout = '';
-    let stderr = '';
-    
+
+    let stdout = "";
+    let stderr = "";
+
     // Collect stdout data
-    server.stdout.on('data', (data) => {
+    server.stdout.on("data", (data) => {
       stdout += data.toString();
     });
-    
+
     // Collect stderr data
-    server.stderr.on('data', (data) => {
+    server.stderr.on("data", (data) => {
       stderr += data.toString();
     });
-    
+
     // Handle process exit
-    server.on('close', (code) => {
+    server.on("close", (code) => {
       if (code !== 0) {
-        reject(new Error(`Server process exited with code ${code}\nStderr: ${stderr}`));
+        reject(
+          new Error(
+            `Server process exited with code ${code}\nStderr: ${stderr}`
+          )
+        );
         return;
       }
-      
+
       try {
         // Parse the response
-        const lines = stdout.trim().split('\n');
-        const responses = lines.map(line => JSON.parse(line) as McpResponse);
+        const lines = stdout.trim().split("\n");
+        const responses = lines.map((line) => JSON.parse(line) as McpResponse);
         resolve(responses);
       } catch (error) {
-        reject(new Error(`Failed to parse server response: ${(error as Error).message}\nStdout: ${stdout}`));
+        reject(
+          new Error(
+            `Failed to parse server response: ${
+              (error as Error).message
+            }\nStdout: ${stdout}`
+          )
+        );
       }
     });
-    
+
     // Send the request to the server
-    server.stdin.write(JSON.stringify(request) + '\n');
+    server.stdin.write(JSON.stringify(request) + "\n");
     server.stdin.end();
   });
 }
@@ -87,47 +97,47 @@ async function sendRequest(request: McpRequest): Promise<McpResponse[]> {
  * Runs the tests
  */
 async function runTests(): Promise<void> {
-  console.log('Running basic tests for Archy MCP server...\n');
-  
+  console.log("Running basic tests for Archy MCP server...\n");
+
   try {
     // Test 1: Initialize the server
-    console.log('Test 1: Initialize the server');
+    console.log("Test 1: Initialize the server");
     const initRequest: McpRequest = {
-      jsonrpc: '2.0',
+      jsonrpc: "2.0",
       id: 1,
-      method: 'initialize',
+      method: "initialize",
       params: {
-        protocolVersion: '0.1.0',
+        protocolVersion: "0.1.0",
         capabilities: {
-          sampling: true
-        }
-      }
+          sampling: true,
+        },
+      },
     };
-    
+
     const initResponse = await sendRequest(initRequest);
-    console.log('Server initialized successfully');
-    console.log('Server capabilities:', initResponse[0]?.result?.capabilities);
-    console.log('');
-    
+    console.log("Server initialized successfully");
+    console.log("Server capabilities:", initResponse[0]?.result?.capabilities);
+    console.log("");
+
     // Test 2: List available tools
-    console.log('Test 2: List available tools');
+    console.log("Test 2: List available tools");
     const listToolsRequest: McpRequest = {
-      jsonrpc: '2.0',
+      jsonrpc: "2.0",
       id: 2,
-      method: 'tools/list'
+      method: "tools/list",
     };
-    
+
     const listToolsResponse = await sendRequest(listToolsRequest);
     const tools = listToolsResponse[0]?.result?.tools || [];
     console.log(`Found ${tools.length} tools:`);
     tools.forEach((tool: any) => {
       console.log(`- ${tool.name}: ${tool.description}`);
     });
-    console.log('');
-    
-    console.log('All tests passed!');
+    console.log("");
+
+    console.log("All tests passed!");
   } catch (error) {
-    console.error('Test failed:', (error as Error).message);
+    console.error("Test failed:", (error as Error).message);
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary
Fixes #2: This PR addresses the issue where build and start scripts reference files that don't exist, and properly relocates TypeScript from dependencies to devDependencies.

## Problem
- Build script references non-existent `build.cjs`
- Start script and bin path point to `build/index.js` when compiled output is in `build/src/index.js`
- TypeScript is listed as a runtime dependency when it should be a dev dependency

## Changes
- Updated `main` and `bin` paths to point to `build/src/index.js`
- Simplified build script to only run TypeScript compiler
- Fixed start script to point to correct output path
- Moved TypeScript from dependencies to devDependencies
- Updated README.md to reflect correct build output paths
- Updated test files to reference correct build output path

## Testing Done
- Successfully ran `npm install`
- Successfully built with `npm run build`
- Verified correct file structure in build directory
- Successfully ran the server with `npm start`
- Tests pass with `npm run test`

## Related Issue
Closes #2
